### PR TITLE
Upgrade simplecov to 0.9.1.

### DIFF
--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'simplecov', '~> 0.7.1'
+  gem.add_dependency 'simplecov', '~> 0.9.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3'


### PR DESCRIPTION
I get "18 examples, 0 failures, 1 pending" via `rake` before and after this change. Functionally, I can verify by anecdote that this change works in my project using this new gemspec with bats 0.4.0 and coveralls 0.7.9 (both latest releases).

Fix #3.

Thanks for bashcov!