### PR TITLE
runner: Use Process.spawn's internal mechanisms to set environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 after_script:
   - cane
   - yard stats --list-undoc

--- a/lib/bashcov/runner.rb
+++ b/lib/bashcov/runner.rb
@@ -14,11 +14,13 @@ module Bashcov
 
       @xtrace = Xtrace.new
       fd = @xtrace.file_descriptor
-      @command = "BASH_XTRACEFD=#{fd} PS4='#{Xtrace::PS4}' #{@command}"
       options = {:in => :in, fd => fd} # bind fds to the child process
       options.merge!({out: '/dev/null', err: '/dev/null'}) if Bashcov.options.mute
 
-      command_pid = Process.spawn @command, options # spawn the command
+      env = {"BASH_XTRACEFD" => "#{fd}", "PS4" => "#{Xtrace::PS4}"}
+      env.merge!(ENV)
+
+      command_pid = Process.spawn env, @command, options # spawn the command
       xtrace_thread = Thread.new { @xtrace.read } # start processing the xtrace output
 
       Process.wait command_pid

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -25,13 +25,14 @@ def expected_coverage
     "#{test_app}/scripts/unicode.sh" => [nil, nil, nil, 1],
     "#{test_app}/scripts/multiline.sh" => [nil, nil, nil, 1, nil, 0, nil, 1, nil, 1, nil, 0, nil, nil, 1, 2, 1, 1, 0, nil, nil, 0, 1, 2],
     "#{test_app}/scripts/executable" => [nil, nil, 1],
-    "#{test_app}/test_suite.sh" => [nil, nil, 2, nil, 1]
+    "#{test_app}/scripts/bashisms" => [nil, nil, nil, 0, nil, nil, nil, 0, nil, nil, 0],
+    "#{test_app}/test_suite.sh" => [nil, nil, 2, nil, 1],
   }
 end
 
 def correct_coverage
   expected_coverage.merge!({
-    "#{test_app}/scripts/multiline.sh" => [nil, nil, 1, 2, 1, 1, 0, nil, nil, 1, 1, 1]
+    "#{test_app}/scripts/multiline.sh" => [nil, nil, nil, 1, nil, 0, nil, 1, nil, 1, nil, 0, nil, nil, 1, 2, 1, 1, 0, nil, nil, 0, 1, 2]
   })
 end
 

--- a/spec/test_app/scripts/bashisms.sh
+++ b/spec/test_app/scripts/bashisms.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function command_substitution {
+    echo
+}
+
+function prints_to_stderr {
+    >&2 echo "data"
+}
+
+prints_to_stderr 2> >(command_substitution)


### PR DESCRIPTION
Don't set the environment as part of the command line as this
will modify argv[0]. This in turn confuses bash into think that
it is running in /bin/sh compatible mode and not /bin/bash mode.

Added a test to verify that we can get coverage on bashisms.

Fixes #5