### PR TITLE
runner: Use Process.spawn's internal mechanisms to set environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 after_script:
   - cane
   - yard stats --list-undoc

--- a/lib/bashcov/runner.rb
+++ b/lib/bashcov/runner.rb
@@ -14,9 +14,11 @@ module Bashcov
 
       @xtrace = Xtrace.new
       fd = @xtrace.file_descriptor
-      @command = "BASH_XTRACEFD=#{fd} PS4='#{Xtrace::PS4}' #{@command}"
       options = {:in => :in, fd => fd} # bind fds to the child process
       options.merge!({out: '/dev/null', err: '/dev/null'}) if Bashcov.options.mute
+
+      ENV["BASH_XTRACEFD"] = "#{fd}"
+      ENV["PS4"] = "#{Xtrace::PS4}"
 
       command_pid = Process.spawn @command, options # spawn the command
       xtrace_thread = Thread.new { @xtrace.read } # start processing the xtrace output

--- a/lib/bashcov/xtrace.rb
+++ b/lib/bashcov/xtrace.rb
@@ -1,3 +1,5 @@
+require 'mkmf'
+
 module Bashcov
   # This class manages +xtrace+ output.
   #
@@ -13,7 +15,10 @@ module Bashcov
     # @see http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
     # @note We use a forward slash as delimiter since it's the only forbidden
     #   character in filenames on Unix and Windows.
-    PS4 = %Q{#{PREFIX}${BASH_SOURCE[0]}/${LINENO}: }
+    _READLINK = find_executable('readlink')
+    _GREADLINK = find_executable('greadlink')
+    READLINK = _GREADLINK.nil? ? _READLINK : _GREADLINK
+    PS4 = %Q{#{PREFIX}$(#{READLINK} -f ${BASH_SOURCE[0]})/${LINENO}: }
 
     # Regexp to match xtrace elements.
     LINE_REGEXP = /\A#{Regexp.escape(PREFIX[0])}+#{PREFIX[1..-1]}(?<filename>.+)\/(?<lineno>\d+): /

--- a/spec/bashcov/runner_spec.rb
+++ b/spec/bashcov/runner_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 require 'benchmark'
 
 describe Bashcov::Runner do
-  let(:runner) { Bashcov::Runner.new test_suite }
+  suite = test_suite
+  let(:runner) { Bashcov::Runner.new "bash #{suite}" }
 
   before :all do
     Dir.chdir File.dirname(test_suite)

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -25,7 +25,7 @@ def expected_coverage
     "#{test_app}/scripts/unicode.sh" => [nil, nil, nil, 1],
     "#{test_app}/scripts/multiline.sh" => [nil, nil, nil, 1, nil, 0, nil, 1, nil, 1, nil, 0, nil, nil, 1, 2, 1, 1, 0, nil, nil, 0, 1, 2],
     "#{test_app}/scripts/executable" => [nil, nil, 1],
-    "#{test_app}/test_suite.sh" => [nil, nil, 2, nil, 1]
+    "#{test_app}/test_suite.sh" => [nil, nil, 2, nil, 1],
   }
 end
 

--- a/spec/test_app/test_suite.sh
+++ b/spec/test_app/test_suite.sh
@@ -2,5 +2,4 @@
 
 cd $(dirname $0)
 
-find scripts -type f -executable -exec '{}' \;
-
+find scripts -type f -perm -111 -exec bash '{}' \;


### PR DESCRIPTION
Don't set the environment as part of the command line as this
will modify argv[0]. This in turn confuses bash into think that
it is running in /bin/sh compatible mode and not /bin/bash mode.

Added a test to verify that we can get coverage on bashisms.

Fixes #5