### PR TITLE
Fix rake tests on OS X

### DIFF
--- a/lib/bashcov/xtrace.rb
+++ b/lib/bashcov/xtrace.rb
@@ -13,7 +13,9 @@ module Bashcov
     # @see http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
     # @note We use a forward slash as delimiter since it's the only forbidden
     #   character in filenames on Unix and Windows.
-    PS4 = %Q{#{PREFIX}${BASH_SOURCE[0]}/${LINENO}: }
+    GET_ABS_DIR = "$(cd $(dirname ${BASH_SOURCE[0]}); pwd)"
+    GET_BASE = "$(basename ${BASH_SOURCE[0]})"
+    PS4 = %Q{#{PREFIX}#{GET_ABS_DIR}/#{GET_BASE}/${LINENO}: }
 
     # Regexp to match xtrace elements.
     LINE_REGEXP = /\A#{Regexp.escape(PREFIX[0])}+#{PREFIX[1..-1]}(?<filename>.+)\/(?<lineno>\d+): /

--- a/spec/bashcov/runner_spec.rb
+++ b/spec/bashcov/runner_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'benchmark'
 
 describe Bashcov::Runner do
-  let(:runner) { Bashcov::Runner.new test_suite }
+  let(:runner) { Bashcov::Runner.new "bash #{test_suite}" }
 
   before :all do
     Dir.chdir File.dirname(test_suite)

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -13,7 +13,7 @@ end
 def expected_coverage
   {
     "#{test_app}/never_called.sh" => [nil, nil, 0],
-    "#{test_app}/scripts/case.sh" => [nil, nil, nil, 2, 1, nil, 0, 0, 1, nil, nil, nil, 1, 1],
+    "#{test_app}/scripts/case.sh" => [nil, nil, nil, 6, 1, nil, 0, 0, 1, nil, nil, nil, 1, 1],
     "#{test_app}/scripts/delete.sh" => [nil, nil, 1, nil, 0, 0, nil, 1, 1],
     "#{test_app}/scripts/function.sh" => [nil, nil, nil, 2, nil, nil, nil, 1, 1, nil, nil, nil, nil, 1, nil, nil, 1, 1, 1],
     "#{test_app}/scripts/long_line.sh" => [nil, nil, 1, 1, 1, 0],

--- a/spec/test_app/test_suite.sh
+++ b/spec/test_app/test_suite.sh
@@ -2,5 +2,4 @@
 
 cd $(dirname $0)
 
-find scripts -type f -executable -exec '{}' \;
-
+find scripts -type f -perm -111 -exec bash '{}' \;


### PR DESCRIPTION
There are some platform-related differences on OS X which cause bashcov not to work correctly, relating to differences between BASH_SOURCE, fd-passing and find.

Fixes #8 