### PR TITLE
Updated exit status to be inherit from the executed command.

### DIFF
--- a/lib/bashcov/runner.rb
+++ b/lib/bashcov/runner.rb
@@ -26,6 +26,10 @@ module Bashcov
 
       @coverage = xtrace_thread.value # wait for the thread to return
 
+      if $?.exitstatus != 0
+        exit $?.exitstatus
+      end
+
       $?
     end
 


### PR DESCRIPTION
Hello @infertux !
after too much fun with travis/coveralls (sorry, i dont used bashcov with any other platforms), i belive that is important to retain the exit status of the executed command (to let travis be notified and dont let him run the event after_success always), and is also important to not send coverage data if the tests failed.

Reading [the comments of the file runner.rb](https://github.com/infertux/bashcov/blob/9a91eef111b6cbb51214f9ff6a7636b6bfeabc79/lib/bashcov/runner.rb#L11), i see that this is the supposed behaviour, but i see that really this is not happening (see [build 134](https://travis-ci.org/ctubio/ctubio.github.io/builds/61209434) with failing tests but exited successfuly [i expected a failed build] and sending coverage data [i expected a skiped coverage post]), or the following simplified command line test:
```bash
[23:40:32] 38 days 1:15 /home/analpaper/lab/bashcov/bin
 $ ./bashcov ../../say_hello_and_exit_with_3; echo $?
Hello
Coverage report generated for bashcov v1.2.0 to /home/analpaper/lab/room0/coverage. 0.0 / 0.0 LOC (100.0%) covered.
0
```
i expected here to get a 3, not a 0 as exit status, no?

then, i brave myself, and made this PR with my first three lines of ruby.. and the result can be seen at [build 135](https://travis-ci.org/ctubio/ctubio.github.io/builds/61214496) were the build failed because the same test failed again, but this time bashcov inherit the exit status nicely to give it to travis; also, any data was send to coveralls. Or [build 136](https://travis-ci.org/ctubio/ctubio.github.io/builds/61219997) with the test fixed and the build becomes passed, posting then the coverage data.

Or the same previous command line test, now results in;
```bash
[23:47:59] 38 days 1:22 /home/analpaper/lab/bashcov/bin
 $ ./bashcov ../../say_hello_and_exit_with_3; echo $?
Hello
3
```
and here all looks fine, but im afraid that my ruby code is not fine at all, so please take this PR as a suggestion rather than a fix by an expert in ruby, cos i am not xD

for the joy of copy&pase, here is the source of say_hello_and_exit_with_3:
```bash
#!/usr/bin/env bash
echo "Hello";
exit 3;
```