### PR TITLE
allow to redefine root directory, merge suites and report to external systems

### DIFF
--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "simplecov", "~> 0.10.0"
-  gem.add_runtime_dependency "coveralls", ">= 0", ">= 0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3"
@@ -28,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "cane"
   gem.add_development_dependency "rubocop"
   gem.add_development_dependency "yard"
+  gem.add_development_dependency "coveralls"
 end

--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "simplecov", "~> 0.10.0"
+  gem.add_runtime_dependency "coveralls", ">= 0", ">= 0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec", "~> 3"
@@ -27,5 +28,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "cane"
   gem.add_development_dependency "rubocop"
   gem.add_development_dependency "yard"
-  gem.add_development_dependency "coveralls"
 end

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -13,14 +13,9 @@ coverage = runner.result
 
 require "simplecov"
 
-if ENV["COVERAGE_DIR"] then
-  SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
-  #SimpleCov.at_exit {
-    #SimpleCov.result
-  #}
-end
+SimpleCov.coverage_dir(ENV["COVERAGE_DIR"]) if ENV["COVERAGE_DIR"]
 
-if ENV["COVERAGE_NAME"] then
+if ENV["COVERAGE_NAME"]
   SimpleCov.command_name ENV["COVERAGE_NAME"]
 else
   SimpleCov.command_name Bashcov.name

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -13,7 +13,19 @@ coverage = runner.result
 
 require "simplecov"
 
-SimpleCov.command_name Bashcov.name
+if ENV["COVERAGE_DIR"] then
+  SimpleCov.coverage_dir(ENV["COVERAGE_DIR"])
+  #SimpleCov.at_exit {
+    #SimpleCov.result
+  #}
+end
+
+if ENV["COVERAGE_NAME"] then
+  SimpleCov.command_name ENV["COVERAGE_NAME"]
+else
+  SimpleCov.command_name Bashcov.name
+end
+
 reports = Bashcov.options.reports
 unless reports.empty?
   formatters = [

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -14,6 +14,17 @@ coverage = runner.result
 require "simplecov"
 
 SimpleCov.command_name Bashcov.name
+reports = Bashcov.options.reports
+unless reports.empty?
+  formatters = [
+    SimpleCov::Formatter::HTMLFormatter
+  ]
+  reports.each do |r|
+    require r[:require]
+    formatters.push(r[:formatter].split("::").inject(Object) { |a, e| a.const_get e })
+  end
+  SimpleCov.formatters = formatters
+end
 SimpleCov.root Bashcov.root_directory
 SimpleCov::Result.new(coverage).format!
 

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -38,6 +38,13 @@ unless reports.empty?
   SimpleCov.formatters = formatters
 end
 SimpleCov.root Bashcov.root_directory
-SimpleCov::Result.new(coverage).format!
+
+result = SimpleCov::Result.new(coverage)
+if SimpleCov.use_merging
+  SimpleCov::ResultMerger.store_result(result) if result
+  result = SimpleCov::ResultMerger.merged_result
+end
+
+result.format!
 
 exit status.exitstatus

--- a/lib/bashcov.rb
+++ b/lib/bashcov.rb
@@ -25,6 +25,7 @@ module Bashcov
       @options ||= OpenStruct.new
       @options.skip_uncovered = false
       @options.mute = false
+      @options.reports = []
     end
 
     # Parses the given CLI arguments and sets +options+.
@@ -72,6 +73,13 @@ module Bashcov
         end
         opts.on("-m", "--mute", "Do not print script output") do |m|
           @options.mute = m
+        end
+        opts.on("-r rep", "--report rep", String, "Report system integration. <require>:<formatter>") do |rep|
+          sp = rep.split(":", 2)
+          report = {}
+          report[:require] = sp[0]
+          report[:formatter] = sp[1]
+          @options.reports.push(report)
         end
 
         opts.separator "\nCommon options:"

--- a/lib/bashcov.rb
+++ b/lib/bashcov.rb
@@ -14,8 +14,9 @@ module Bashcov
     attr_reader :options
 
     # @return [String] The project's root directory
-    def root_directory
-      @root_directory ||= Dir.pwd
+    def root_directory(root = nil)
+      return @root_directory if defined?(@root_directory) && root.nil?
+      @root_directory = root || Dir.pwd
     end
 
     # Sets default options overriding any existing ones.

--- a/lib/bashcov/xtrace.rb
+++ b/lib/bashcov/xtrace.rb
@@ -55,6 +55,21 @@ module Bashcov
         @files[filename] ||= []
         @files[filename][lineno] ||= 0
         @files[filename][lineno] += 1
+        line = File.readlines(filename)[lineno]
+        ishere = line.match("cat.*<<-?\s*[\"']?\(.*\)[\"']?")
+        next unless ishere
+        lineno += 1
+        line = File.readlines(filename)[lineno]
+        until line.nil? || line.match("^\s*#{ishere[1]}")
+          @files[filename][lineno] ||= 0
+          @files[filename][lineno] += 1
+          lineno += 1
+          line = File.readlines(filename)[lineno]
+        end
+        unless line.nil?
+          @files[filename][lineno] ||= 0
+          @files[filename][lineno] += 1
+        end
       end
 
       @files

--- a/spec/bashcov_spec.rb
+++ b/spec/bashcov_spec.rb
@@ -71,6 +71,15 @@ describe Bashcov do
           }
         end
       end
+
+      context "with the --report option" do
+        before { @args << "--report" << "req:Module::Formatter" }
+
+        it "sets it properly" do
+          subject
+          expect(Bashcov.options.reports).to eq([{ require: "req", formatter: "Module::Formatter" }])
+        end
+      end
     end
   end
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -14,8 +14,9 @@ def expected_coverage
   {
     "#{test_app}/never_called.sh" => [nil, nil, 0],
     "#{test_app}/scripts/case.sh" => [nil, nil, nil, 6, 1, nil, 0, 0, 1, nil, nil, nil, 1, 1],
-    "#{test_app}/scripts/delete.sh" => [nil, nil, 1, nil, 0, 0, nil, 1, 1],
+    "#{test_app}/scripts/delete.sh" => [nil, nil, 1, 1, 1, 1, 1, 2, 2],
     "#{test_app}/scripts/function.sh" => [nil, nil, nil, 2, nil, nil, nil, 1, 1, nil, nil, nil, nil, 1, nil, nil, 1, 1, 1],
+    "#{test_app}/scripts/heredocuments.sh" => [nil, nil, 1, 1, 1, nil, 1, 1, 1, 1, 1, 1, nil, 1, 1, 1, 1, 1],
     "#{test_app}/scripts/long_line.sh" => [nil, nil, 1, 1, 1, 0],
     "#{test_app}/scripts/nested/simple.sh" => [nil, nil, nil, nil, 1, 1, nil, 0, nil, nil, 1],
     "#{test_app}/scripts/one_liner.sh" => [nil, nil, 2, nil, 1, nil, 0],

--- a/spec/test_app/scripts/heredocuments.sh
+++ b/spec/test_app/scripts/heredocuments.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+cat << EOF
+Showing text
+EOF
+
+cat <<- END
+   Another couple
+of lines
+ - list 1
+ - list 2
+END
+
+cat <<- FINISH
+ Complex
+   important
+      message
+FINISH
+


### PR DESCRIPTION
Mimic behaviour of simplecov to allow bashcov to produce output on a directory different from current dir.

See it working here. 

https://github.com/albfan/git-ignore/blob/master/.travis.yml

git-ignore is test with sharness, which creates a sandbox for every test group.

A way to configure bashcov is wanted too. See the hack on every test to read .simplecov

https://github.com/albfan/git-ignore/blob/master/t/t0001-exclude.sh#L11
