### PR TITLE
Merge coverage results from multiple runs using unique command names

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,4 +1,7 @@
 SimpleCov.start do
   minimum_coverage 95
+  add_filter "/features/"
   add_filter "/spec/"
+  add_filter "/tmp/"
+  add_filter "/.git/"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased ([changes](https://github.com/infertux/bashcov/compare/v1.7.0...master))
 
-  * TBD
+  * [FEATURE] Merge coverage results from multiple runs when
+              `SimpleCov.use_merging` is set to `true`. Auto-generate
+              likely-unique values for `SimpleCov.command_name`, providing the
+              `--command-name` option and `BASHCOV_COMMAND_NAME` environment
+              variable for users to set a command name explicitly (#34)
 
 ## v1.7.0, 2017-12-28 ([changes](https://github.com/infertux/bashcov/compare/v1.6.0...v1.7.0))
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,35 @@ your project's root (like [this](https://github.com/infertux/bashcov/blob/master
 See [SimpleCov README](https://github.com/colszowka/simplecov#readme) for more
 information.
 
+#### Controlling the command name
+
+Bashcov respects all of your `.simplecov` settings save one --
+[`SimpleCov.command_name`](http://www.rubydoc.info/gems/simplecov/SimpleCov/Configuration#command_name-instance_method),
+which is the tag that SimpleCov attaches to coverage results from a particular
+test suite. You can set the value of `SimpleCov.command_name` by using
+Bashcov's `--command-name` option, or by assigning a value to the environment
+variable `BASHCOV_COMMAND_NAME`. Otherwise, Bashcov will generate a command
+name for you based on the name of the currently-executing Bash script and any
+arguments passed to it. For example, assuming your Bash lives at `/bin/bash`
+and you run the command
+
+```
+$ bashcov -- ./test_suite.sh --and some --flags
+```
+
+Bashcov will set `SimpleCov.command_name` to `"/bin/bash ./test_suite.sh --and
+some --flags"`. Basing `SimpleCov.command_name` on the executing command helps
+to ensure that multiple coverage runs don't [overwrite each other's
+results](https://github.com/colszowka/simplecov#test-suite-names) due to
+SimpleCov identifying multiple runs by the same tag. The `--command-name` and
+`BASHCOV_COMMAND_NAME` knobs are there for you to twiddle in case your test
+suite runs the exact same `bashcov` command more than once, in which case the
+generated command name will not distinguish each invocation from the others.
+
+For more info on `SimpleCov.command_name` and its relation to SimpleCov's
+result-merging behavior, see the [SimpleCov
+README](https://github.com/colszowka/simplecov#merging-results).
+
 ### Some gory details
 
 Figuring out where an executing Bash script lives in the file system can be

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,9 @@
 
 require "bundler/gem_tasks"
 
+require "cucumber/rake/task"
+Cucumber::Rake::Task.new
+
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.ruby_opts = "-w"
@@ -10,4 +13,4 @@ end
 require "rubocop/rake_task"
 RuboCop::RakeTask.new
 
-task default: %i[rubocop spec]
+task default: %i[rubocop spec cucumber]

--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "simplecov", "~> 0.15"
 
-  gem.add_development_dependency "aruba"
+  gem.add_development_dependency "aruba", "~> 0.14.3"
   gem.add_development_dependency "coveralls"
   gem.add_development_dependency "cucumber"
   gem.add_development_dependency "mutant-rspec"

--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "simplecov", "~> 0.15"
 
+  gem.add_development_dependency "aruba"
   gem.add_development_dependency "coveralls"
+  gem.add_development_dependency "cucumber"
   gem.add_development_dependency "mutant-rspec"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -23,6 +23,9 @@ if SimpleCov.use_merging
   result = SimpleCov::ResultMerger.merged_result
 end
 
-SimpleCov.at_exit { result.format! }
+SimpleCov.at_exit do
+  puts "Run completed using #{Bashcov.fullname}"
+  result.format!
+end
 
 exit status.exitstatus

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -14,6 +14,8 @@ coverage = runner.result
 
 require "simplecov"
 
+SimpleCov.start
+
 SimpleCov.command_name Bashcov.command_name
 SimpleCov.root Bashcov.root_directory
 

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -16,6 +16,13 @@ require "simplecov"
 
 SimpleCov.command_name Bashcov.command_name
 SimpleCov.root Bashcov.root_directory
-SimpleCov.at_exit { SimpleCov::Result.new(coverage).format! }
+
+result = SimpleCov::Result.new(coverage)
+if SimpleCov.use_merging
+  SimpleCov::ResultMerger.store_result(result)
+  result = SimpleCov::ResultMerger.merged_result
+end
+
+SimpleCov.at_exit { result.format! }
 
 exit status.exitstatus

--- a/bin/bashcov
+++ b/bin/bashcov
@@ -14,7 +14,7 @@ coverage = runner.result
 
 require "simplecov"
 
-SimpleCov.command_name Bashcov.fullname
+SimpleCov.command_name Bashcov.command_name
 SimpleCov.root Bashcov.root_directory
 SimpleCov.at_exit { SimpleCov::Result.new(coverage).format! }
 

--- a/features/command_name.feature
+++ b/features/command_name.feature
@@ -1,0 +1,60 @@
+Feature:
+
+  Users can control the command name used for identifying SimpleCov's coverage
+  results through an environment variable or a command-line option; by default
+  Bashcov auto-generates a unique(-ish) command name based on the command
+  Bashcov was asked to execute.
+
+  Background:
+
+    Given SimpleCov is configured with:
+      """
+      require "simplecov"
+      SimpleCov.configure do
+        use_merging true
+      end
+      """
+
+    And a file named "test.sh" with mode "0755" and with:
+      """
+      #!/bin/bash
+      date
+      """
+
+  Scenario: no explicit command name is provided
+
+    When I run the following commands with bashcov:
+      """
+      ./test.sh
+      """
+
+    Then the results should contain the commands:
+      | /bin/bash ./test.sh |
+
+  Scenario: the command name is set with `--command-name`
+
+    When I run the following commands with bashcov using `--command-name hey-i-am-a-command`:
+      """
+      ./test.sh
+      """
+
+    And I run the following commands with bashcov using `--command-name cool-i-am-a-command-too`:
+      """
+      ./test.sh
+      """
+
+    Then the results should contain the commands:
+      | hey-i-am-a-command |
+      | cool-i-am-a-command-too |
+
+  Scenario: the command name is provided with `$BASHCOV_COMMAND_NAME`
+
+    When I set the environment variable "BASHCOV_COMMAND_NAME" to "mytestsuite"
+
+    And I run the following commands with bashcov:
+      """
+      ./test.sh
+      """
+
+    Then the results should contain the commands:
+      | mytestsuite |

--- a/features/result_merging.feature
+++ b/features/result_merging.feature
@@ -1,0 +1,62 @@
+Feature:
+
+  When Bashcov is run more than once and SimpleCov is configured to merge the
+  results of multiple runs, each run should have a unique command name, and the
+  results from each run should be merged together.  However, if command names
+  are not unique, only the last-run command should appear in the coverage
+  results.
+
+  Background:
+
+    Given SimpleCov is configured with:
+      """
+      require "simplecov"
+      SimpleCov.configure do
+        use_merging true
+      end
+      """
+
+    And a file named "simple.sh" with mode "0755" and with:
+      """
+      #!/bin/bash
+      tr '[[:lower:]]' '[[:upper:]]' <<<'shhh'
+      """
+
+  Scenario: SimpleCov.use_merging == true and SimpleCov.command_name is unique
+
+    When I run the following commands with bashcov using `--command-name simple-test-1`:
+      """
+      ./simple.sh
+      """
+
+    And I run the following commands with bashcov using `--command-name simple-test-2`:
+      """
+      ./simple.sh
+      """
+
+    Then the results should contain the commands:
+      | simple-test-1 |
+      | simple-test-2 |
+
+    And the file "./simple.sh" should have the following coverage:
+      | 1 | nil |
+      | 2 | 2 |
+
+  Scenario: SimpleCov.use_merging == true and SimpleCov.command_name is not unique
+
+    When I run the following commands with bashcov using `--command-name simple-test`:
+      """
+      ./simple.sh
+      """
+
+    And I run the following commands with bashcov using `--command-name simple-test`:
+      """
+      ./simple.sh
+      """
+
+    Then the results should contain the commands:
+      | simple-test |
+
+    And the file "./simple.sh" should have the following coverage:
+      | 1 | nil |
+      | 2 | 1 |

--- a/features/step_definitions/bashcov_steps.rb
+++ b/features/step_definitions/bashcov_steps.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "aruba/api"
+require "json"
+require "simplecov"
+
+# Convenience methods for use in step definitions
+module StepHelpers
+  include Aruba::Api
+
+  def aruba_setting(setting_name)
+    Aruba.configure { |config| return config.public_send(setting_name) }
+  end
+
+  def aruba_working_directory_expanded
+    File.expand_path(aruba_setting(:working_directory), aruba_setting(:root_directory))
+  end
+
+  def simplecov_results_json
+    run_simple(<<-'COMMAND', fail_on_error: false)
+      ruby -rjson -rsimplecov -e '
+        SimpleCov.at_exit { } # noop to prevent output other than the desired JSON
+        print SimpleCov::ResultMerger.results.map(&:to_hash).to_json
+      '
+    COMMAND
+
+    last_command_started.stdout
+  end
+
+  def simplecov_results_from_json(doc)
+    JSON.parse(doc).map { |raw| SimpleCov::Result.from_hash(raw) }
+  end
+
+  def simplecov_results
+    simplecov_results_from_json(simplecov_results_json)
+  end
+
+  def simplecov_merged_result
+    SimpleCov::ResultMerger.merge_results(*simplecov_results)
+  end
+end
+
+World(StepHelpers)
+
+Given(/^SimpleCov is configured(?: in ("[^"]"))? with:$/) do |config_dir, config_body|
+  simplecov_config_path = File.join(*[config_dir, ".simplecov"].compact.reject(&:empty?))
+
+  steps %(
+    Given a file named "#{simplecov_config_path}" with:
+      """
+      #{config_body}
+      """
+    Then the file "#{simplecov_config_path}" should exist
+  )
+end
+
+When(/I run the following commands with bashcov(?: using `([^`]+)`)?:$/) do |options, commands|
+  unless (options ||= "--root .").include? "--root"
+    options << " --root ."
+  end
+
+  steps %(
+    When I run the following commands:
+      """
+      #{commands.each_line.map { |command| "bashcov #{options} -- #{command}" }.join("\n")}
+      """
+  )
+end
+
+Then(/^the results should contain the commands:$/) do |table|
+  results = simplecov_results
+  commands = table.raw.flatten
+  expect(results.map(&:command_name)).to include(*commands)
+end
+
+Then(/^the file "([^"]*)" should have the following coverage:/) do |filename, table|
+  filename = File.expand_path(filename, aruba_working_directory_expanded)
+
+  merged_result = simplecov_merged_result
+  original_result = merged_result.original_result
+
+  expect(original_result).to include(filename), %(coverage includes results for "#{filename}")
+
+  file_coverage = original_result[filename]
+
+  table.raw.each do |line_number, coverage|
+    line_number = line_number.to_i
+
+    coverage = coverage == "nil" ? nil : coverage.to_i
+
+    expect(file_coverage[line_number - 1]).to(
+      eq(coverage),
+      %(line #{line_number} of "#{filename}" has coverage `#{coverage}`)
+    )
+  end
+end

--- a/features/step_definitions/bashcov_steps.rb
+++ b/features/step_definitions/bashcov_steps.rb
@@ -17,7 +17,7 @@ module StepHelpers
   end
 
   def simplecov_results_json
-    run_simple(<<-'COMMAND', fail_on_error: false)
+    run_simple(<<-'COMMAND')
       ruby -rjson -rsimplecov -e '
         SimpleCov.at_exit { } # noop to prevent output other than the desired JSON
         print SimpleCov::ResultMerger.results.map(&:to_hash).to_json

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "aruba/cucumber"
+
+Aruba.configure do |config|
+  config.log_level         = :debug
+  config.exit_timeout      = 0.5
+  config.startup_wait_time = 1
+end

--- a/lib/bashcov.rb
+++ b/lib/bashcov.rb
@@ -14,7 +14,7 @@ module Bashcov
 
   # A +Struct+ to store Bashcov configuration
   Options = Struct.new(
-    *%i[skip_uncovered mute bash_path root_directory command]
+    *%i[skip_uncovered mute bash_path root_directory command command_name]
   )
 
   class << self
@@ -68,6 +68,16 @@ module Bashcov
       ].join(" ")
     end
 
+    # @return [String] The value to use as +SimpleCov.command_name+. Uses the
+    #   value of +--command-name+, if this flag was provided, or
+    #   +BASHCOV_COMMAND_NAME, if set, defaulting to a stringified
+    #   representation of {Bashcov#command}.
+    def command_name
+      return @options.command_name if @options.command_name
+      return ENV["BASHCOV_COMMAND_NAME"] unless ENV.fetch("BASHCOV_COMMAND_NAME", "").empty?
+      command.compact.join(" ")
+    end
+
     # Wipe the current options and reset default values
     def set_default_options!
       @options = Options.new
@@ -112,6 +122,9 @@ module Bashcov
         opts.on("--root PATH", "Project root directory") do |d|
           raise Errno::ENOENT, d unless File.directory? d
           options.root_directory = d
+        end
+        opts.on("--command-name NAME", "Value to use as SimpleCov.command_name") do |c|
+          options.command_name = c
         end
 
         opts.separator "\nCommon options:"

--- a/lib/bashcov.rb
+++ b/lib/bashcov.rb
@@ -18,15 +18,6 @@ module Bashcov
   )
 
   class << self
-    # Define option accessors
-    Options.new.members.each do |option|
-      [option, "#{option}="].each do |method|
-        define_method method do |*args|
-          options.public_send(*[method, *args])
-        end
-      end
-    end
-
     # @return [Struct] The +Struct+ object representing Bashcov configuration
     def options
       set_default_options! unless defined?(@options)
@@ -86,6 +77,17 @@ module Bashcov
       @options.mute             = false
       @options.bash_path        = "/bin/bash"
       @options.root_directory   = Dir.getwd
+    end
+
+    # Define option accessors
+    Options.new.members.each do |option|
+      [option, "#{option}="].each do |method|
+        next if instance_methods(false).include?(method)
+
+        define_method method do |*args|
+          options.public_send(*[method, *args])
+        end
+      end
     end
 
   private

--- a/lib/bashcov.rb
+++ b/lib/bashcov.rb
@@ -53,9 +53,9 @@ module Bashcov
       [
         program_name,
         VERSION,
-        "(with Bash #{BASH_VERSION},",
+        "with Bash #{BASH_VERSION},",
         "Ruby #{RUBY_VERSION},",
-        "and SimpleCov #{SimpleCov::VERSION})",
+        "and SimpleCov #{SimpleCov::VERSION}.",
       ].join(" ")
     end
 

--- a/lib/bashcov/field_stream.rb
+++ b/lib/bashcov/field_stream.rb
@@ -36,9 +36,6 @@ module Bashcov
     def each(delimiter, field_count, start_match)
       return enum_for(__method__, delimiter, field_count, start_match) unless block_given?
 
-      # Whether the current field is the start-of-fields match
-      matched_start = nil
-
       # The number of fields processed since passing the last start-of-fields
       # match
       seen_fields = 0
@@ -58,7 +55,6 @@ module Bashcov
           # Fill out any remaining (unparseable) fields with empty strings
           yield_remaining.call
 
-          matched_start = nil
           seen_fields = 0
         elsif seen_fields < field_count
           yield field

--- a/spec/bashcov_spec.rb
+++ b/spec/bashcov_spec.rb
@@ -31,7 +31,7 @@ describe Bashcov do
   describe ".command_name" do
     before { Bashcov.command = ["touch", "/tmp/a/file"] }
 
-    it "Includes .command stringified" do
+    it "includes .command stringified" do
       expect(Bashcov.command_name).to eq Bashcov.command.compact.join(" ")
     end
   end

--- a/spec/bashcov_spec.rb
+++ b/spec/bashcov_spec.rb
@@ -28,6 +28,14 @@ describe Bashcov do
     end
   end
 
+  describe ".command_name" do
+    before { Bashcov.command = ["touch", "/tmp/a/file"] }
+
+    it "Includes .command stringified" do
+      expect(Bashcov.command_name).to eq Bashcov.command.compact.join(" ")
+    end
+  end
+
   describe ".mute" do
     it "delegates to .options" do
       Bashcov.options.mute = true


### PR DESCRIPTION
This is a work-in-progress branch that addresses the result-merging issue raised in #28.

@infertux -- I'm not sure if I'm overdoing it with the introduction of feature tests.  I figure it's not a big deal from the point of view of introducing new dependencies (since SimpleCov already depends on Cucumber and Aruba), and the plain-language approach felt right for describing the kinds of behaviours introduced by these changes.  But it should be fairly straightforward to rework the specs in plain old RSpec, too.

The changesets are in a rough-ish state at the moment; I'll clean everything up and rebase if and when I get the go-ahead.  Thanks in advance!