### PR TITLE
Apply simplecov filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased ([changes](https://github.com/infertux/bashcov/compare/v1.8.2...master))
 
-  * TBD
+  * [FEATURE] Bashcov omits from the coverage results any files that match one
+              or more of the filters in `SimpleCov.filters`.
+  * [FEATURE] Ensure that files matching the `SimpleCov.tracked_files` glob
+              pattern are included in the coverage results, regardless of
+              whether `Bashcov.skip_uncovered` is enabled.
 
 ## v1.8.2, 2018-03-27 ([changes](https://github.com/infertux/bashcov/compare/v1.8.1...v1.8.2))
 

--- a/spec/bashcov/xtrace_spec.rb
+++ b/spec/bashcov/xtrace_spec.rb
@@ -46,9 +46,10 @@ describe Bashcov::Xtrace do
 
     context "when shell expansion triggers subshell execution" do
       it "causes extra hits to be reported" do
+        allow(Bashcov).to receive(:skip_uncovered).at_least(:once).and_return(true)
+
         result_without_subshell = case_result
 
-        allow(Bashcov).to receive(:skip_uncovered).and_return(true)
         allow(Bashcov::Xtrace).to receive(:ps4).and_return(subshell_ps4)
 
         result_with_subshell = case_result

--- a/spec/bashcov_spec.rb
+++ b/spec/bashcov_spec.rb
@@ -18,7 +18,7 @@ end
 
 describe Bashcov do
   it "preserves the exit status" do
-    system("./bin/bashcov ./spec/test_app/scripts/exit_non_zero.sh")
+    system("./bin/bashcov --root ./spec/test_app ./spec/test_app/scripts/exit_non_zero.sh")
     expect($?.exitstatus).not_to eq(0)
   end
 

--- a/spec/support/test_app.rb
+++ b/spec/support/test_app.rb
@@ -52,3 +52,23 @@ def expected_missing
     "#{test_app}/scripts/no_extension/usr_local_bin_gawk",
   ]
 end
+
+def expected_omitted
+  {
+    ->(source_file) { File.basename(File.dirname(source_file.project_filename)) != "scripts" } => [
+      "#{test_app}/never_called.sh",
+    ],
+    /multiline(?:\d)*/ => [
+      "#{test_app}/multiline.sh",
+      "#{test_app}/multiline2.sh",
+      "#{test_app}/multiline3.sh",
+    ],
+    "/no_extension/" => [
+      "#{test_app}/scripts/no_extension/bin_bash",
+      "#{test_app}/scripts/no_extension/bin_bash_with_args",
+      "#{test_app}/scripts/no_extension/bin_dash",
+      "#{test_app}/scripts/no_extension/bin_sh",
+      "#{test_app}/scripts/no_extension/usr_bin_env_bash",
+    ],
+  }
+end


### PR DESCRIPTION
This changeset introduces a new flag, `--prefilter`, which causes Bashcov to omit from the coverage results any files that match one or more of the filters in `SimpleCov.filters`.

The motivation for this feature is that SimpleCov itself will ignore these files, so Bashcov is doing work (e.g., detecting whether a file is a shell script) only for that work to be thrown away.  This is especially problematic when `Bashcov.root_directory` sits at the top of a large directory hierarchy; e.g., a project that includes vendored dependencies.

I've made this behavior optional, in case there are any projects in the wild that depend on Bashcov's current approach to generating the coverage results hash.  However, I tend to think that this behavior should be the default.  Thoughts, @infertux?

