### PR TITLE
FieldStream#each: return early if reader is at EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased ([changes](https://github.com/infertux/bashcov/compare/v2.0.0...master))
 
-  * TBD
+  * [BUGFIX]  Correctly handle empty scripts by short-circuiting
+              `FieldStream#each` if the reader stream is at end-of-file before
+              the start-of-fields pattern is encountered (#41)
 
 ## v2.0.0, 2018-12-?? ([changes](https://github.com/infertux/bashcov/compare/v1.8.2...v2.0.0))
 

--- a/bashcov.gemspec
+++ b/bashcov.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "simplecov", "0.15.1"
 
-  gem.add_development_dependency "aruba", "~> 0.14.3"
+  gem.add_development_dependency "aruba", ">= 0.14"
   gem.add_development_dependency "bundler-audit"
   gem.add_development_dependency "coveralls"
   gem.add_development_dependency "cucumber"

--- a/lib/bashcov/xtrace.rb
+++ b/lib/bashcov/xtrace.rb
@@ -97,6 +97,8 @@ module Bashcov
         parse_hit!(*hit)
       end
 
+      @read.close unless @read.closed?
+
       @files
     end
 

--- a/spec/bashcov/field_stream_spec.rb
+++ b/spec/bashcov/field_stream_spec.rb
@@ -51,5 +51,25 @@ describe Bashcov::FieldStream do
           yield_successive_args(*expected)
       end
     end
+
+    context "when the stream is empty or already fully consumed" do
+      let(:read) { StringIO.new }
+
+      it "short-circuits without yielding anything" do
+        expect { |e| stream.each(delimiter, field_count, start_match, &e) }.not_to yield_control
+      end
+    end
+
+    context "when stream contains fields prior to the first start-of-fields match" do
+      let(:before_start) { %w[some junk data] }
+      let(:after_start)  { %w[the good stuff] }
+      let(:field_count)  { 3 }
+      let(:input)        { (before_start + [start] + after_start).join(delimiter) }
+
+      it "discards them" do
+        expect { |e| stream.each(delimiter, field_count, start_match, &e) }.to \
+          yield_successive_args(*after_start)
+      end
+    end
   end
 end

--- a/spec/bashcov/runner_spec.rb
+++ b/spec/bashcov/runner_spec.rb
@@ -147,6 +147,18 @@ describe Bashcov::Runner do
       end
     end
 
+    context "given an empty script" do
+      include_context "temporary script", "empty_script" do
+        let(:script_text) { "" }
+      end
+
+      it "returns empty coverage results" do
+        expect { tmprunner.run }.not_to raise_error
+        expect(tmprunner.result).to include(tmpscript.path)
+        expect(tmprunner.result[tmpscript.path]).to be_empty
+      end
+    end
+
     context "given a version of Bash prior to 4.1", if: Bashcov::BASH_VERSION < "4.1" do
       include_context "temporary script", "no_stderr" do
         let(:stderr_output) { "AIEEE!" }


### PR DESCRIPTION
Closes #41.

Empty files and files that consist entirely of whitespace are valid shell scripts.  However, since such scripts contain nothing for Bash to execute, Bash will never expand `PS4` and the `FieldStream` object responsible for handling Bash's execution tracing output has nothing to do.  This PR corrects a bug in `FieldStream` in which the `#each` method yields a set of empty strings, as though Bash's execution tracing output were prematurely terminated or otherwise unparseable, when in fact it should yield nothing at all.

@infertux -- would appreciate a sanity-check here :)