### PR TITLE
Fix comments preceded by tabs not filtered out

### DIFF
--- a/lib/bashcov/lexer.rb
+++ b/lib/bashcov/lexer.rb
@@ -96,7 +96,7 @@ module Bashcov
     end
 
     def relevant?(line)
-      line.sub!(/ #.*\Z/, "") # remove comments
+      line.sub!(/\s#.*\Z/, "") # remove comments
       line.strip!
 
       relevant = true

--- a/spec/test_app/scripts/comments.sh
+++ b/spec/test_app/scripts/comments.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+case "space" in
+  space) # comment
+    echo space
+    ;;
+esac
+
+case "tab" in
+  tab)	# comment
+    echo tab
+    ;;
+esac


### PR DESCRIPTION
Match any whitespace before `#`, not just spaces.