### PR TITLE
bugfix in detective.rb

### DIFF
--- a/lib/bashcov/detective.rb
+++ b/lib/bashcov/detective.rb
@@ -53,8 +53,9 @@ module Bashcov
       end
 
       return false unless shebang[0..1] == "#!"
-
       shell, arg = shebang[2..].split(/\s+/, 2)
+
+      return false unless shell != nil
       shell_basename = File.basename(shell)
 
       SHELL_BASENAMES.include?(shell_basename) ||


### PR DESCRIPTION
executing the script `bashcov example.sh` in a sufficiently complex project raises
```ruby
`basename': no implicit conversion of nil into String (TypeError)
      shell_basename = File.basename(shell)
```
in cases where
```
shebang: #!
shell: 
arg: 
```
this PR is a workaround