### PR TITLE
Bashcov::Detector: handle non-UTF-8 data

### DIFF
--- a/lib/bashcov/detective.rb
+++ b/lib/bashcov/detective.rb
@@ -86,6 +86,8 @@ module Bashcov
       SHELLSCRIPT_EXTENSIONS.include? File.extname(filename)
     end
 
+  private
+
     # @param [String,Pathname] filename the name of the file to be checked
     # @return [Boolean] whether +filename+'s text matches valid shell syntax
     # @note assumes that +filename+ is readable and refers to a regular file

--- a/lib/bashcov/detective.rb
+++ b/lib/bashcov/detective.rb
@@ -58,13 +58,19 @@ module Bashcov
     def shellscript_shebang_line?(shebang)
       scanner = StringScanner.new(shebang)
 
-      return false if scanner.scan(/#!\s*/).nil?
+      begin
+        return false if scanner.scan(/#!\s*/).nil?
 
-      shell = scanner.scan(/\S+/)
+        shell = scanner.scan(/\S+/)
 
-      return false if shell.nil?
+        return false if shell.nil?
 
-      args = scanner.skip(/\s+/).nil? ? [] : scanner.rest.split(/\s+/)
+        args = scanner.skip(/\s+/).nil? ? [] : scanner.rest.split(/\s+/)
+      rescue ArgumentError
+        # Handle "invalid byte sequence in UTF-8" from `StringScanner`.  Can
+        # happen when trying to read binary data (e.g. .pngs).
+        return false
+      end
 
       shell_basename = File.basename(shell)
 

--- a/spec/bashcov/detective_spec.rb
+++ b/spec/bashcov/detective_spec.rb
@@ -14,8 +14,10 @@ describe Bashcov::Detective do
     let(:envs)        { combine(["env", "env -S"]) }
     let(:notenvs)     { combine(["false", "hello --world"]) }
     let(:valid)       { make_shebangs(shells) }
+    let(:png)         { "\x89PNG\r\n" }
+
     let(:invalid) do
-      ["", "\n", "\t\n", "foo"] + make_shebangs(notshells) + shebangify(with_executors(combine(shells), executors: notenvs))
+      ["", "\n", "\t\n", "foo", png] + make_shebangs(notshells) + shebangify(with_executors(combine(shells), executors: notenvs))
     end
 
     def combine(candidates)


### PR DESCRIPTION
Follow-up to #73 and #74.  Recover from `ArgumentError` scanning through the first line of a file looking for a shell shebang (`StringScanner` raises an `ArgumentError` on bad/unexpected encodings/data).