### PR TITLE
feat(LEXER): support function names containing dots

### DIFF
--- a/lib/bashcov/lexer.rb
+++ b/lib/bashcov/lexer.rb
@@ -104,7 +104,7 @@ module Bashcov
                       line.start_with?(*IGNORE_START_WITH) ||
                       line.end_with?(*IGNORE_END_WITH)
 
-      return false if line =~ /\A[a-zA-Z_][a-zA-Z0-9_\-:]*\(\)/ # function declared without the `function` keyword
+      return false if line =~ /\A[a-zA-Z_][a-zA-Z0-9_\-:\.]*\(\)/ # function declared without the `function` keyword
       return false if line =~ /\A[^)]+\)\Z/ # case statement selector, e.g. `--help)`
 
       true

--- a/spec/test_app/scripts/function.sh
+++ b/spec/test_app/scripts/function.sh
@@ -18,11 +18,11 @@ put-team-key() {
   echo put-team-key # 0
 }
 
-abc::def() {
+abc::def.fn() {
     echo "${FUNCNAME[0]}" # 1
 }
 
 f1 # 1
 f2 # 1
 __a-bc # 1
-abc::def # 1
+abc::def.fn # 1


### PR DESCRIPTION
Bash supports having dots in function names:

```pseudo.oo.fn() { echo "hello there"; }```

This short commit expands the regex to support this usage.
